### PR TITLE
BUGFIX: _site-settings.scss

### DIFF
--- a/scss/tools/_site-settings.scss
+++ b/scss/tools/_site-settings.scss
@@ -5,7 +5,7 @@
 // ----------------------
 
 // Html 5 Element
-$audio-canvas-video: flase; // True | False
+$audio-canvas-video: false; // True | False
 
 // Fonts
 $font1: "Helvetica Neue", Helvetica, Arial, sans-serif;


### PR DESCRIPTION
Corrected spelling error in _site-settings.scss: 
    -canvas-video boolean was set to "flase"
    -canvas-video boolean now set to "false"
- Jason
